### PR TITLE
Mz tab validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>uk.ac.ebi.pride.px</groupId>
     <artifactId>px-submission-tool</artifactId>
     <packaging>jar</packaging>
-    <version>2.8.1</version>
+    <version>2.8.2</version>
     <name>px-submission-tool</name>
     <url>https://github.com/proteomexchange/px-submission-tool</url>
 

--- a/src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java
+++ b/src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java
@@ -511,8 +511,9 @@ public class FileScanAndValidationTask extends TaskAdapter<DataFileValidationMes
                     }
 
                     if (hasPSH && hasPSM && i >= limit) {
-                        break;
-                    }
+                        if (line != null && !line.isEmpty()) {
+                            String[] fields = line.split("\t");
+                            if(fields.length < 2){
 
                     if (i < limit) {
                         String[] fields = line.split("\t");

--- a/src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java
+++ b/src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java
@@ -492,8 +492,7 @@ public class FileScanAndValidationTask extends TaskAdapter<DataFileValidationMes
                     throw new IllegalArgumentException("The file is empty.");
                 }
 
-                // Process the first 100 lines or the total number of lines, whichever is smaller
-                int limit = Math.min(100, lines.size());
+                int limit = 100;
                 boolean hasPSH = false;
                 boolean hasPSM = false;
 

--- a/src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java
+++ b/src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java
@@ -485,7 +485,8 @@ public class FileScanAndValidationTask extends TaskAdapter<DataFileValidationMes
         List<DataFile> invalidFiles = new ArrayList<>();
         for (DataFile dataFile : mzTabDataFiles) {
             try {
-                if (Files.size(Paths.get(dataFile.getFilePath())) > MAX_FILE_SIZE) {
+                try (BufferedReader reader = Files.newBufferedReader(Paths.get(dataFile.getFilePath()))) {
+                    List lines = reader.lines().collect(Collectors.toList());
                     throw new IllegalArgumentException("File is too large to process");
                 }
                 List lines = Files.readAllLines(Paths.get(dataFile.getFilePath()));

--- a/src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java
+++ b/src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java
@@ -492,7 +492,7 @@ public class FileScanAndValidationTask extends TaskAdapter<DataFileValidationMes
                 List lines = Files.readAllLines(Paths.get(dataFile.getFilePath()));
 
                 // Check if the file is empty
-                if (lines.isEmpty()) {
+                private static final int LINE_VALIDATION_LIMIT = 100;
                     throw new IllegalArgumentException("The file is empty.");
                 }
 

--- a/src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java
+++ b/src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java
@@ -485,7 +485,10 @@ public class FileScanAndValidationTask extends TaskAdapter<DataFileValidationMes
         List<DataFile> invalidFiles = new ArrayList<>();
         for (DataFile dataFile : mzTabDataFiles) {
             try {
-                List<String> lines = Files.readAllLines(Paths.get(dataFile.getFilePath()));
+                if (Files.size(Paths.get(dataFile.getFilePath())) > MAX_FILE_SIZE) {
+                    throw new IllegalArgumentException("File is too large to process");
+                }
+                List lines = Files.readAllLines(Paths.get(dataFile.getFilePath()));
 
                 // Check if the file is empty
                 if (lines.isEmpty()) {


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced mzTab file validation logic with new checks.

- Limited mzTab file parsing to the first 100 lines.

- Improved error handling for empty or improperly formatted files.

- Updated project version in `pom.xml` to 2.8.2.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FileScanAndValidationTask.java</strong><dd><code>Enhanced mzTab file validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/uk/ac/ebi/pride/gui/task/FileScanAndValidationTask.java

<li>Replaced full document parsing with line-by-line validation.<br> <li> Added checks for empty files and tab-delimited format.<br> <li> Introduced a 100-line limit for parsing.<br> <li> Improved error handling for missing PSH and PSM lines.


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/px-submission-tool/pull/157/files#diff-e32a60bf9e3fcd0a475d7fcc5b4260e4fb9209ee606a702312dd728ecc6ee15f">+59/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Incremented project version in pom.xml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pom.xml

- Updated project version from 2.8.1 to 2.8.2.


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/px-submission-tool/pull/157/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information