### PR TITLE
wording fix -  crosslinking MS

### DIFF
--- a/src/main/resources/cv/msmethod.cv
+++ b/src/main/resources/cv/msmethod.cv
@@ -2,7 +2,7 @@ PRIDE	PRIDE:0000427	Top-down proteomics	Top-down proteomics
 PRIDE	PRIDE:0000428	Bottom-up proteomics	Bottom-up proteomics
 PRIDE	PRIDE:0000627	Data-dependent acquisition	Data-dependent acquisition
 PRIDE	PRIDE:0000450	Data-independent acquisition	Data-independent acquisition
-PRIDE	PRIDE:0000430	Chemical cross-linking coupled with mass spectrometry proteomics	Cross-linking (CX-MS)
+PRIDE	PRIDE:0000430	Chemical cross-linking coupled with mass spectrometry proteomics	Crosslinking MS
 PRIDE	PRIDE:0000447	SWATH MS	SWATH MS
 PRIDE	PRIDE:0000451	MSE	MSE
 PRIDE	PRIDE:0000452	HDMSE	HDMSE


### PR DESCRIPTION
This will not effect to the CV term as PRIDE CV Term is mapped to the word "Crosslinking MS"

CV Term:
PRIDE	PRIDE:0000430	Chemical cross-linking coupled with mass spectrometry proteomics	**Crosslinking MS**
